### PR TITLE
Package: onedir builds on all platforms + Windows installer + Linux CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
             name: windows-x64
           - os: macos-latest
             name: macos-arm64
+          - os: ubuntu-24.04
+            name: linux-x64
 
     steps:
       - uses: actions/checkout@v4
@@ -37,17 +39,40 @@ jobs:
       - name: Build with PyInstaller
         run: uv run pyinstaller Flim-Playground.spec --clean
 
-      # macOS ships as tar.gz so the executable bit survives download —
-      # zip artifacts and browser downloads strip it. Tarring dist/Flim-Playground
-      # with the dist/ prefix matches the assets of past releases.
+      # All three platforms ship onedir builds (fast startup, no per-launch
+      # self-extraction). macOS and Linux are tarred so the executable bit
+      # survives download (zip strips it): macOS wraps the onedir in
+      # Flim-Playground.app, Linux ships the Flim-Playground/ folder. Windows
+      # wraps the onedir folder in a single per-user installer via Inno Setup
+      # (Flim-Playground-Setup.exe): the user downloads one file, it installs
+      # once and adds shortcuts, then every launch is full onedir speed.
       - name: Stage release files
         shell: bash
+        env:
+          APP_VERSION: ${{ github.event.release.tag_name || '0.0.0-dev' }}
         run: |
           mkdir -p release
           if [ "$RUNNER_OS" = "macOS" ]; then
-            tar -czf release/Flim-Playground-mac.tar.gz dist/Flim-Playground
+            tar -czf release/Flim-Playground-mac.tar.gz -C dist Flim-Playground.app
+          elif [ "$RUNNER_OS" = "Linux" ]; then
+            # onedir folder dist/Flim-Playground/ (the Flim-Playground binary +
+            # _internal/), tarred from inside dist/ so it extracts to
+            # Flim-Playground/ with no dist/ prefix. Same tar handling as macOS
+            # (preserve the exec bit); macOS just wraps its onedir in the .app.
+            tar -czf release/Flim-Playground-linux.tar.gz -C dist Flim-Playground
           else
-            cp dist/Flim-Playground.exe release/
+            # Brand the Setup exe: build logo.ico from logo.png (padded to a
+            # transparent square so the 320x207 logo isn't squished into the
+            # square icon slots). Kept out of the repo — logo.png is the source.
+            uv run python -c "from PIL import Image; im = Image.open('logo.png').convert('RGBA'); side = max(im.size); sq = Image.new('RGBA', (side, side), (0, 0, 0, 0)); sq.paste(im, ((side - im.width) // 2, (side - im.height) // 2)); sq.save('logo.ico', sizes=[(16, 16), (24, 24), (32, 32), (48, 48), (64, 64), (128, 128), (256, 256)])"
+            # Inno Setup is usually pre-installed on windows-latest; install via
+            # choco as a fallback so the build doesn't depend on the runner image.
+            ISCC=$(find "/c/Program Files (x86)" -maxdepth 2 -name ISCC.exe 2>/dev/null | head -1)
+            if [ -z "$ISCC" ]; then
+              choco install innosetup --no-progress -y
+              ISCC=$(find "/c/Program Files (x86)" -maxdepth 2 -name ISCC.exe 2>/dev/null | head -1)
+            fi
+            "$ISCC" Flim-Playground.iss
           fi
 
       - name: Upload workflow artifact

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 .DS_Store
 dist/
 build/
+logo.ico
 .vscode/
 test.py
 .venv/

--- a/Flim-Playground.iss
+++ b/Flim-Playground.iss
@@ -1,0 +1,71 @@
+; Inno Setup script — wraps the PyInstaller onedir output (dist\Flim-Playground)
+; into a single per-user installer: Flim-Playground-Setup.exe.
+;
+; Why per-user (PrivilegesRequired=lowest), not Program Files:
+; the app saves config.toml beside its own exe via get_persistent_dir(), so the
+; install directory must stay user-writable. A per-machine Program Files install
+; would need admin AND would make config saves fail for standard users. In
+; non-admin mode {autopf} resolves to %LOCALAPPDATA%\Programs\Flim-Playground,
+; which the user owns — config writes there succeed and no UAC prompt appears.
+;
+; Version comes from the APP_VERSION env var (set by the CI release tag),
+; falling back to a dev placeholder for manual/workflow_dispatch builds.
+
+#define AppName "Flim-Playground"
+#define AppExe "Flim-Playground.exe"
+#define AppVersion GetEnv("APP_VERSION")
+#if AppVersion == ""
+  #define AppVersion "0.0.0-dev"
+#endif
+
+[Setup]
+AppId={{8F3B2A10-9C4D-4E1F-B7A6-1D2E3F4A5B6C}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher=Skala Lab
+DefaultDirName={autopf}\{#AppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=lowest
+OutputDir=release
+OutputBaseFilename=Flim-Playground-Setup
+; Brands the Setup exe itself. logo.ico is generated from logo.png by the CI
+; staging step (not committed) — regenerate locally with the same Pillow
+; snippet in build.yml if compiling by hand.
+SetupIconFile=logo.ico
+UninstallDisplayName={#AppName}
+UninstallDisplayIcon={app}\{#AppExe}
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional icons:"
+
+; On an in-place upgrade, wipe the previous version's PyInstaller payload before
+; copying the new one so renamed/removed bundled files (e.g. a deleted page that
+; Streamlit auto-discovers) don't linger and mix versions. Scoped to _internal\
+; — config.toml/analysis_config.toml live at {app}\ root beside the exe, so they
+; are untouched and survive the upgrade.
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\_internal"
+
+[Files]
+Source: "dist\{#AppName}\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
+
+[Icons]
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent
+
+; The uninstaller already removes everything installed via [Files]; only the
+; runtime-created configs (written next to the exe, untracked by [Files]) and
+; any runtime .pyc left under _internal\ need explicit cleanup. Scoped to those
+; — NOT the whole {app} — so installing into a pre-existing user-chosen folder
+; can't wipe unrelated files on uninstall. Runs only on uninstall, never on
+; upgrade, so configs persist across upgrades.
+[UninstallDelete]
+Type: files; Name: "{app}\config.toml"
+Type: files; Name: "{app}\analysis_config.toml"
+Type: filesandordirs; Name: "{app}\_internal"

--- a/Flim-Playground.spec
+++ b/Flim-Playground.spec
@@ -52,19 +52,22 @@ a = Analysis(
 )
 pyz = PYZ(a.pure)
 
+# onedir on all platforms: onefile re-extracted the whole ~450MB bundle to a
+# temp dir on every launch (tens of seconds, worse under antivirus scanning);
+# onedir materializes it once and starts in seconds. Users get
+# Flim-Playground.app on macOS and a Flim-Playground/ folder on Linux (both
+# tarred for download), and the same folder wrapped in a one-file installer on
+# Windows — each with configs saved beside the app.
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.datas,
     [],
+    exclude_binaries=True,
     name='Flim-Playground',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    upx_exclude=[],
-    runtime_tmpdir=None,
     console=False,
     disable_windowed_traceback=False,
     argv_emulation=False,
@@ -72,4 +75,21 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
     icon=['logo.png'],
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='Flim-Playground',
+)
+# macOS only (explicit no-op on other platforms): wrap the onedir folder in a
+# .app bundle so Finder launches it without a Terminal window and shows the icon.
+app = BUNDLE(
+    coll,
+    name='Flim-Playground.app',
+    icon='logo.png',
+    bundle_identifier='com.skalalab.flim-playground',
 )

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ pyinstaller Flim-Playground.spec --clean
 ```
 
 ## Upgrade
-Already running an older version? Upgrading is simple — **just replace the old app with the new one** (download the latest from the Releases tab, or rebuild from source).
+Already running an older version? Upgrading is simple — on **macOS** and **Linux**, just replace the old app with the new one; on **Windows**, just run the new installer and it upgrades your existing installation in place (download the latest from the Releases tab, or rebuild from source).
 
-Your settings carry over automatically. `config.toml` (Data Extraction settings) and `analysis_config.toml` (Data Analysis settings, if you have one) are **not** bundled inside the app, so swapping in the new app leaves them untouched. Just keep these files in the **same folder as the app**, and all your profiles and settings will be there in the new version.
+Your settings carry over automatically. `config.toml` (Data Extraction settings) and `analysis_config.toml` (Data Analysis settings, if you have one) are **not** bundled inside the app, so upgrading leaves them untouched. On **macOS and Linux**, just keep these files in the **same folder as the app**; on **Windows**, they live in the install folder and survive upgrades on their own — all your profiles and settings will be there in the new version.
 
 # Documentation
 - @[docs](https://skalalab.github.io/flim_playground_doc/)

--- a/src/config.py
+++ b/src/config.py
@@ -3,13 +3,29 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+def get_persistent_dir() -> Path:
+    """Directory for runtime-writable config, beside the app the user launched.
+
+    In a macOS .app bundle sys.executable is
+    ``<dir>/Flim-Playground.app/Contents/MacOS/Flim-Playground``; we walk up out
+    of the bundle to ``<dir>`` so config lands next to the .app — mirroring where
+    Windows puts it next to the .exe. Writing inside ``Contents/`` would hide the
+    file from Finder and break the code-signature seal. On Windows/Linux the exe
+    isn't in that layout, so we fall back to the executable's own directory.
+    """
+    exe = Path(sys.executable)
+    if exe.parent.name == "MacOS" and exe.parent.parent.name == "Contents":
+        return exe.parent.parent.parent.parent  # directory containing the .app
+    return exe.parent
+
+
 def _get_config_path() -> Path:
     """Get the config file path, handling both development and bundled app scenarios."""
     # Check if running as a PyInstaller bundle
     if getattr(sys, '_MEIPASS', None):
-        # Running as bundled app - persist config next to the executable.
+        # Running as bundled app - persist config next to the app.
         # config.toml is no longer bundled; main.py seeds defaults on first run.
-        return Path(sys.executable).parent / "config.toml"
+        return get_persistent_dir() / "config.toml"
     else:
         # Running in development mode - use config.toml in project root
         return Path(__file__).resolve().parent.parent / "config.toml"

--- a/src/widgets/analysis_config_widgets.py
+++ b/src/widgets/analysis_config_widgets.py
@@ -2,7 +2,7 @@ import streamlit as st
 from streamlit_sortables import sort_items
 from pathlib import Path
 import sys
-from src.config import load_config, save_config, get_unique_cell_id_col, get_fov_name_col, get_all_feature_extractors, get_categorical_cols
+from src.config import load_config, save_config, get_unique_cell_id_col, get_fov_name_col, get_all_feature_extractors, get_categorical_cols, get_persistent_dir
 
 # Maximum number of profiles allowed
 MAX_PROFILES = 10
@@ -11,9 +11,9 @@ def _get_analysis_config_path() -> Path:
     """Get the analysis config file path, handling both development and bundled app scenarios."""
     # Check if running as a PyInstaller bundle
     if getattr(sys, '_MEIPASS', None):
-        # Running as bundled app - save config to a persistent location
-        # Use the directory where the executable is located
-        exe_dir = Path(sys.executable).parent
+        # Running as bundled app - save config next to the app (out of the
+        # macOS .app bundle so it's visible and doesn't break the signature).
+        exe_dir = get_persistent_dir()
         config_path = exe_dir / "analysis_config.toml"
         
         # If config doesn't exist in exe directory, try to copy from bundle


### PR DESCRIPTION
- Add ubuntu-24.04 (linux-x64) to the CI matrix; ship Flim-Playground-linux.tar.gz (onedir folder tarred to preserve the exec bit, like macOS)
- Windows: wrap the onedir folder in a per-user Inno Setup installer (Flim-Playground-Setup.exe) with scoped [InstallDelete]/[UninstallDelete] so config survives in-place upgrades and uninstall can't wipe a user-chosen folder
- Unified onedir spec (EXE + COLLECT + BUNDLE); BUNDLE is a no-op off macOS
- get_persistent_dir() persists config beside the app on all three platforms
- README Upgrade section split by platform; logo.ico generated in CI (gitignored)