### PR TITLE
Linux: ship a desktop launcher so it matches macOS/Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,18 @@ jobs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             tar -czf release/Flim-Playground-mac.tar.gz -C dist Flim-Playground.app
           elif [ "$RUNNER_OS" = "Linux" ]; then
-            # onedir folder dist/Flim-Playground/ (the Flim-Playground binary +
-            # _internal/), tarred from inside dist/ so it extracts to
-            # Flim-Playground/ with no dist/ prefix. Same tar handling as macOS
-            # (preserve the exec bit); macOS just wraps its onedir in the .app.
+            # Desktop integration so Linux users get a clickable, iconed launcher
+            # like macOS/Windows instead of a bare binary. Drop a square PNG icon
+            # (padded from logo.png, same idea as the Windows .ico) plus
+            # install.sh/uninstall.sh INSIDE the onedir folder; the user runs
+            # ./install.sh once to register a "FLIM Playground" menu entry.
+            uv run python -c "from PIL import Image; im = Image.open('logo.png').convert('RGBA'); side = max(im.size); sq = Image.new('RGBA', (side, side), (0, 0, 0, 0)); sq.paste(im, ((side - im.width) // 2, (side - im.height) // 2)); sq.resize((256, 256)).save('dist/Flim-Playground/flim-playground.png')"
+            cp linux/install.sh linux/uninstall.sh dist/Flim-Playground/
+            chmod +x dist/Flim-Playground/install.sh dist/Flim-Playground/uninstall.sh
+            # onedir folder dist/Flim-Playground/ (binary + _internal/ + the icon
+            # and scripts just added), tarred from inside dist/ so it extracts to
+            # Flim-Playground/ with no dist/ prefix and keeps the exec bits (zip
+            # would strip them). macOS wraps its onedir in the .app instead.
             tar -czf release/Flim-Playground-linux.tar.gz -C dist Flim-Playground
           else
             # Brand the Setup exe: build logo.ico from logo.png (padded to a

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ You can try out analysis modules in the **Data Analysis** section using this sam
 
 # Install
 ## Option 1: Download from Releases
-- Releases for Mac OS 26, Windows 11, Ubuntu 24.04 LTS (look for the latest ones under the Releases tab on the right)
+Grab the latest build for your OS under the **Releases** tab on the right (available for macOS, Windows 11, and Ubuntu 24.04 LTS):
+- **macOS** — download `Flim-Playground-mac.tar.gz`, unzip, and double-click **Flim-Playground.app**.
+- **Windows** — download `Flim-Playground-Setup.exe`, run the installer, then launch from the **Start Menu** shortcut it creates.
+- **Linux** (Ubuntu 24.04+) — download `Flim-Playground-linux.tar.gz`, extract it, and run `./install.sh` once from the extracted folder to add **FLIM Playground** to your application menu; then click it to launch. (Or run the `Flim-Playground` binary directly.)
 ## Option 2: Build from source
 ### Clone the repo
 ```bash
@@ -55,9 +58,10 @@ Then Navigate into the repository once cloned.
 ```bash
 pyinstaller Flim-Playground.spec --clean
 ```
+This produces a ready-to-run app folder (`dist/Flim-Playground/`, or `Flim-Playground.app` on macOS) you can launch directly. The Windows `Setup.exe` installer is built separately by CI (Inno Setup), so a from-source build on Windows gives you the runnable app folder rather than an installer.
 
 ## Upgrade
-Already running an older version? Upgrading is simple — on **macOS** and **Linux**, just replace the old app with the new one; on **Windows**, just run the new installer and it upgrades your existing installation in place (download the latest from the Releases tab, or rebuild from source).
+Already running an older version? Upgrading is simple — on **macOS** and **Linux**, just replace the old app with the new one; on **Windows**, just run the new installer and it upgrades your existing installation in place (download the latest from the Releases tab). On **Linux**, re-run `./install.sh` only if you moved the folder to a new location.
 
 Your settings carry over automatically. `config.toml` (Data Extraction settings) and `analysis_config.toml` (Data Analysis settings, if you have one) are **not** bundled inside the app, so upgrading leaves them untouched. On **macOS and Linux**, just keep these files in the **same folder as the app**; on **Windows**, they live in the install folder and survive upgrades on their own — all your profiles and settings will be there in the new version.
 

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Add FLIM Playground to your application menu.
+#
+# The download is a self-contained folder, so there is nothing to "install" in
+# the traditional sense — this just registers a clickable, iconed launcher
+# (a freedesktop .desktop entry) pointing at the app where it currently sits, so
+# you can start it from your app menu / Activities like a native program instead
+# of running the binary by hand. Re-run this if you move the folder. Undo any
+# time with ./uninstall.sh — neither script touches your data.
+
+set -euo pipefail
+
+APP_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN="$APP_DIR/Flim-Playground"
+ICON="$APP_DIR/flim-playground.png"
+DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+DESKTOP_FILE="$DESKTOP_DIR/flim-playground.desktop"
+
+if [ ! -f "$BIN" ]; then
+  echo "Error: could not find the Flim-Playground launcher next to this script ($BIN)." >&2
+  echo "Run install.sh from inside the extracted Flim-Playground folder." >&2
+  exit 1
+fi
+chmod +x "$BIN" 2>/dev/null || true   # restore the exec bit if the download lost it
+
+mkdir -p "$DESKTOP_DIR"
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Name=FLIM Playground
+Comment=Interactive single-cell FLIM data extraction and analysis
+Exec="$BIN"
+Icon=$ICON
+Terminal=false
+Categories=Education;Science;
+StartupNotify=true
+EOF
+
+# Refresh the menu database if the helper exists (best-effort; not on every distro).
+command -v update-desktop-database >/dev/null 2>&1 && \
+  update-desktop-database "$DESKTOP_DIR" >/dev/null 2>&1 || true
+
+echo "✅ FLIM Playground is now in your application menu."
+echo "   Search for \"FLIM Playground\" in your launcher / Activities and click it to run."
+echo "   Moved the folder? Just run ./install.sh again. Remove it with ./uninstall.sh."

--- a/linux/uninstall.sh
+++ b/linux/uninstall.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Remove the FLIM Playground application-menu launcher created by install.sh.
+# This only removes the menu entry — it does NOT delete the app folder or your
+# config files (config.toml / analysis_config.toml).
+
+set -euo pipefail
+
+DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+DESKTOP_FILE="$DESKTOP_DIR/flim-playground.desktop"
+
+if [ -f "$DESKTOP_FILE" ]; then
+  rm -f "$DESKTOP_FILE"
+  command -v update-desktop-database >/dev/null 2>&1 && \
+    update-desktop-database "$DESKTOP_DIR" >/dev/null 2>&1 || true
+  echo "✅ Removed the FLIM Playground menu entry."
+else
+  echo "No FLIM Playground menu entry found — nothing to remove."
+fi
+echo "   Your app folder and config files were left untouched."


### PR DESCRIPTION
The Linux onedir download was a bare binary with no icon and no menu entry — users had to run the executable by hand. Ship a square PNG icon plus install.sh/uninstall.sh inside the tarball; ./install.sh registers a freedesktop .desktop entry, giving a clickable "FLIM Playground" launcher in the application menu like the macOS .app and the Windows Start Menu shortcut. uninstall.sh removes only the menu entry, never the app or config.

README download/upgrade steps rewritten per platform (incl. the Linux ./install.sh step) and the from-source build note now clarifies it yields the app folder, not the Windows installer.